### PR TITLE
change build method to `make` from `sh build.sh`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,4 +19,4 @@ jobs:
         extended: true
 
     - name: Build
-      run: sh build.sh
+      run: make

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
         extended: true
 
     - name: Build
-      run: sh build.sh
+      run: make
 
     - name: Sync files
       uses: SamKirkland/FTP-Deploy-Action@4.3.2

--- a/Makefile
+++ b/Makefile
@@ -28,12 +28,12 @@ blog:
 # Serve top page without blog.
 test-index:
 	$(SUBMOD_UPDATE)
-	cd $(INDEX_DIR); $(TEST) $(INDEX_ARGS)
+	cd $(INDEX_DIR); $(TEST)
 
 # Serve blog site.
 test-blog:
 	$(SUBMOD_UPDATE)
-	cd $(BLOG_DIR); $(TEST) $(BLOG_ARGS)
+	cd $(BLOG_DIR); $(TEST)
 
 # Clean the generated product.
 clean:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .SUFFIXES:
 
-CC := hugo --minify --gc
+CC := hugo --minify
 TEST := hugo server --port 1313
 
 SUBMOD_UPDATE := git submodule update --recursive

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .SUFFIXES:
 
 CC := hugo --minify
-TEST := hugo server --port 1313
+TEST := hugo server
 
 SUBMOD_UPDATE := git submodule update --recursive
 

--- a/Makefile
+++ b/Makefile
@@ -38,3 +38,6 @@ test-blog:
 # Clean the generated product.
 clean:
 	rm -rf $(OUTPUT)
+	@for f in $(shell git ls-files --other --ignored --exclude-standard); do\
+		rm -rf $$f;\
+	done

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,40 @@
+.SUFFIXES:
+
+CC := hugo --minify --gc
+TEST := hugo server --baseURL http://localhost/ --port 1313
+
+SUBMOD_UPDATE := git submodule update --recursive
+
+OUTPUT := html
+
+INDEX_DIR := index
+BLOG_DIR:= blog
+
+.PHONY: all index blog clean test-index test-blog
+
+# Build all.
+all: index blog
+
+# Build top page without blog.
+index:
+	$(SUBMOD_UPDATE)
+	cd $(INDEX_DIR); $(CC) -d ../$(OUTPUT)
+
+# Build blog site.
+blog:
+	$(SUBMOD_UPDATE)
+	cd $(BLOG_DIR); $(CC) -d ../$(OUTPUT)/blog
+
+# Serve top page without blog.
+test-index:
+	$(SUBMOD_UPDATE)
+	cd $(INDEX_DIR); $(TEST) $(INDEX_ARGS)
+
+# Serve blog site.
+test-blog:
+	$(SUBMOD_UPDATE)
+	cd $(BLOG_DIR); $(TEST) $(BLOG_ARGS)
+
+# Clean the generated product.
+clean:
+	rm -rf $(OUTPUT)

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .SUFFIXES:
 
 CC := hugo --minify --gc
-TEST := hugo server --baseURL http://localhost/ --port 1313
+TEST := hugo server --port 1313
 
 SUBMOD_UPDATE := git submodule update --recursive
 

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,0 @@
-cd index
-hugo --minify -d ../html
-cd ../blog
-hugo --minify -d ../html/blog


### PR DESCRIPTION
The build method is changed from `sh build.sh` to `make`. This change makes
sense because we can not only build all, but also do partial builds, run `hugo
server`, and clean up the product in one place.

GitHub Actions are modified and tested on [act](https://github.com/nektos/act).

# Commands

| Command                 |                        |
|:------------------------|:-----------------------|
| `make`                  | Build all.             |
| `make index` `make blog`| Partially build.       |
| `make test-index` `make test-blog` | Run `hugo server --baseURL http://localhost --port 1313`. |
| `make clean`            | Delete `./html`.       |

# Change Log

- changed build.sh to Makefile
- update github actions to use make
