### PR TITLE
add init option updating submodules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 CC := hugo --minify
 TEST := hugo server
 
-SUBMOD_UPDATE := git submodule update --recursive
+SUBMOD_UPDATE := git submodule update --init --recursive
 
 OUTPUT := html
 


### PR DESCRIPTION
Currently using `git submodule update --recursive` to update submodules.
This will not even initialize the submodule when it is started for the first time, so the corresponding directory will remain empty.
Switched the cmd to `git submodule update --init --recursive` to deal with this problem.
